### PR TITLE
Enable -isystem for third-party headers on Ubuntu

### DIFF
--- a/inst/tools/workaround.R
+++ b/inst/tools/workaround.R
@@ -22,7 +22,8 @@ if ((.Platform$OS.type == "windows" && !file.exists("src/Makevars.win"))) {
 if (.Platform$OS.type == "windows" || R.version$os == "linux-musl") {
   .i <- "I"
 } else {
-  if (any(grepl("Pop!_OS", utils::osVersion, fixed=TRUE))) {
+  if (any(grepl("Pop!_OS", utils::osVersion, fixed=TRUE)) ||
+        any(grepl("Ubuntu", utils::osVersion, fixed=TRUE))) {
     .i <- "isystem"
   } else {
     .i <- "I"


### PR DESCRIPTION
## What

`inst/tools/workaround.R` only selected `-isystem` (vs plain `-I`) for third-party headers (BH, RcppEigen, Rcpp, StanHeaders) on Pop!_OS, falling back to `-I` everywhere else. On Ubuntu this exposed **~9,300** `-Wignored-attributes` / `-Wdeprecated-declarations` warnings from RcppEigen and boost on every build, burying any real diagnostic from rxode2ll's own code.

## Why

None of these warnings come from rxode2ll's own source — they're all third-party Eigen/boost. Sibling package **rxode2 already selects `-isystem` for both Pop!_OS and Ubuntu**; this just adds the missing `Ubuntu` branch so the two stay consistent and third-party headers are correctly treated as system headers.

```r
if (any(grepl("Pop!_OS", utils::osVersion, fixed=TRUE)) ||
      any(grepl("Ubuntu", utils::osVersion, fixed=TRUE))) {
  .i <- "isystem"
}
```

## Impact

- Ubuntu (incl. GitHub Actions runners): ~9,300 → 0 warnings.
- Other platforms: unchanged (still `-I`, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)